### PR TITLE
fix: rename bifrost networks to indicate relay

### DIFF
--- a/chaindata.json
+++ b/chaindata.json
@@ -526,7 +526,7 @@
   },
   {
     "id": "bifrost-kusama",
-    "name": "Bifrost",
+    "name": "Bifrost - Kusama",
     "account": "*25519",
     "subscanUrl": "https://bifrost-kusama.subscan.io/",
     "chainspecQrUrl": "https://metadata.novasama.io/qr/bifrost_specs.png",
@@ -581,7 +581,7 @@
   },
   {
     "id": "bifrost-polkadot",
-    "name": "Bifrost",
+    "name": "Bifrost - Polkadot",
     "account": "*25519",
     "subscanUrl": "https://bifrost.subscan.io/",
     "chainspecQrUrl": "https://metadata.novasama.io/qr/bifrost_polkadot_specs.png",


### PR DESCRIPTION
Both networks were called "Bifrost".
Renamed them to "Bifrost - Kusama" and "Bifrost - Polkadot"