### PR TITLE
fix: remove blastapi nodes for moon chains

### DIFF
--- a/chaindata.json
+++ b/chaindata.json
@@ -1941,11 +1941,10 @@
     "account": "secp256k1",
     "subscanUrl": "https://moonbeam.subscan.io/",
     "rpcs": [
-      "wss://1rpc.io/glmr",
-      "wss://moonbeam.public.blastapi.io",
       "wss://wss.api.moonbeam.network",
       "wss://moonbeam.api.onfinality.io/public-ws",
-      "wss://moonbeam.unitedbloc.com"
+      "wss://moonbeam.unitedbloc.com",
+      "wss://1rpc.io/glmr"
     ],
     "paraId": 2004,
     "relay": {
@@ -1958,7 +1957,6 @@
     "account": "secp256k1",
     "subscanUrl": "https://moonriver.subscan.io/",
     "rpcs": [
-      "wss://moonriver.public.blastapi.io",
       "wss://wss.api.moonriver.moonbeam.network",
       "wss://moonriver.api.onfinality.io/public-ws",
       "wss://moonriver.unitedbloc.com"

--- a/testnets-chaindata.json
+++ b/testnets-chaindata.json
@@ -439,7 +439,6 @@
     "account": "secp256k1",
     "subscanUrl": "https://moonbase.subscan.io/",
     "rpcs": [
-      "wss://moonbase-alpha.public.blastapi.io",
       "wss://wss.api.moonbase.moonbeam.network",
       "wss://moonbeam-alpha.api.onfinality.io/public-ws",
       "wss://moonbase.unitedbloc.com"


### PR DESCRIPTION
blastapi rpcs throw an error when attempting to transfer native tokens with substrate api