### PR TITLE
Update eth mainnet default tokens

### DIFF
--- a/data/evm-networks.json
+++ b/data/evm-networks.json
@@ -12,24 +12,9 @@
       "evm-erc20": {
         "tokens": [
           {
-            "symbol": "xcRMRK",
-            "contractAddress": "0x471Ea49dd8E60E697f4cac262b5fafCc307506e4",
-            "coingeckoId": "rmrk"
-          },
-          {
-            "symbol": "ASTAR",
-            "contractAddress": "0x67f6b5bc5670fd29bcc8af3d6633b2840aba2f30",
-            "coingeckoId": "astar"
-          },
-          {
             "symbol": "USDC",
             "contractAddress": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
             "coingeckoId": "usd-coin"
-          },
-          {
-            "symbol": "WCFG",
-            "contractAddress": "0xc221b7e65ffc80de234bbb6667abdd46593d34f0",
-            "coingeckoId": "wrapped-centrifuge"
           },
           {
             "symbol": "USDT",
@@ -44,6 +29,26 @@
           {
             "symbol": "stETH",
             "contractAddress": "0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84"
+          },
+          {
+            "symbol": "rETH",
+            "contractAddress": "0xae78736Cd615f374D3085123A210448E74Fc6393",
+            "coingeckoId": "rocket-pool-eth"
+          },
+          {
+            "symbol": "LINK",
+            "contractAddress": "0x514910771af9ca656af840dff83e8264ecf986ca",
+            "coingeckoId": "chainlink"
+          },
+          {
+            "symbol": "WBTC",
+            "contractAddress": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
+            "coingeckoId": "wrapped-bitcoin"
+          },
+          {
+            "symbol": "SHIB",
+            "contractAddress": "0x95aD61b0a150d79219dCF64E1E6Cc01f0B64C4cE",
+            "coingeckoId": "shiba-inu"
           }
         ]
       }


### PR DESCRIPTION
Remove substrate erc20 coins, and add large mcap erc20s to default tokens for ethereum mainnet