### PR TITLE
Set "isDefault": false to some evm testnets

### DIFF
--- a/data/evm-networks.json
+++ b/data/evm-networks.json
@@ -58,6 +58,7 @@
     "id": "5",
     "name": "Goerli",
     "isTestnet": true,
+    "isDefault": false,
     "explorerUrl": "https://goerli.etherscan.io",
     "rpcs": ["https://rpc.ankr.com/eth_goerli"],
     "balancesConfig": {
@@ -471,8 +472,9 @@
   {
     "id": "595",
     "substrateChainId": "mandala-testnet",
+    "isDefault": false,
     "isTestnet": true,
-    "rpcs": ["https://tc7-eth.aca-dev.network"]
+    "rpcs": ["wss://eth-rpc-tc9.aca-staging.network"]
   },
   {
     "id": "1287",

--- a/data/evm-networks.json
+++ b/data/evm-networks.json
@@ -474,7 +474,7 @@
     "substrateChainId": "mandala-testnet",
     "isDefault": false,
     "isTestnet": true,
-    "rpcs": ["wss://eth-rpc-tc9.aca-staging.network"]
+    "rpcs": ["https://eth-rpc-tc9.aca-staging.network"]
   },
   {
     "id": "1287",


### PR DESCRIPTION
Not sure if Mandala is really dead but quite sure we do not need it on by default