### PR TITLE
Revert "chore: remove mythos due to bad prefix (#130)"

### DIFF
--- a/data/chaindata.json
+++ b/data/chaindata.json
@@ -3112,6 +3112,16 @@
     }
   },
   {
+    "id": "mythos",
+    "name": "Mythos",
+    "account": "*25519",
+    "rpcs": ["wss://polkadot-mythos-rpc.polkadot.io"],
+    "paraId": 3369,
+    "relay": {
+      "id": "polkadot"
+    }
+  },
+  {
     "id": "neatcoin",
     "name": "Neatcoin",
     "account": "*25519",


### PR DESCRIPTION
This reverts commit d362ae6169c21875bf3abc9d1b6c8bb90662ea10.