### PR TITLE
chore: remove failing rpc from moonbeam rpc list

### DIFF
--- a/data/chaindata.json
+++ b/data/chaindata.json
@@ -3062,7 +3062,6 @@
     "subscanUrl": "https://moonbeam.subscan.io/",
     "rpcs": [
       "wss://moonbeam-rpc.dwellir.com",
-      "wss://1rpc.io/glmr",
       "wss://wss.api.moonbeam.network",
       "wss://moonbeam.public.curie.radiumblock.co/ws",
       "wss://moonbeam.unitedbloc.com"


### PR DESCRIPTION
RPC fails with error:
`Unsupported subscription: state_subscribeStorage`

This error type is not caught properly in Talisman's rpc fallback logic.