### PR TITLE
feat: add analog-testnet logo, token and portal

### DIFF
--- a/data/testnets-chaindata.json
+++ b/data/testnets-chaindata.json
@@ -48,7 +48,15 @@
     "id": "analog-testnet",
     "name": "Analog Testnet",
     "account": "*25519",
-    "rpcs": ["wss://rpc.testnet.analog.one"]
+    "chainspecQrUrl": "https://metadata.analog.one/qr/analog-testnet_specs.png",
+    "latestMetadataQrUrl": "https://metadata.analog.one/qr/analog-testnet_metadata_latest.apng",
+    "rpcs": ["wss://rpc.testnet.analog.one"],
+    "themeColor": "#5d3ef8",
+    "balancesConfig": {
+      "substrate-native": {
+        "logo": "./assets/tokens/tanlog.svg"
+      }
+    }
   },
   {
     "id": "arctic-testnet-rococo",

--- a/pub/v1/chains/all.json
+++ b/pub/v1/chains/all.json
@@ -10643,8 +10643,8 @@
     "genesisHash": "0x0614f7b74a2e47f7c8d8e2a5335be84bdde9402a43f5decdec03200a87c8b943",
     "prefix": 12850,
     "name": "Analog Testnet",
-    "themeColor": "#505050",
-    "logo": "https://raw.githubusercontent.com/TalismanSociety/chaindata/main/assets/chains/unknown.svg",
+    "themeColor": "#5d3ef8",
+    "logo": "https://raw.githubusercontent.com/TalismanSociety/chaindata/main/assets/chains/analog-testnet.svg",
     "chainName": "Analog Testnet",
     "chainType": "Live",
     "implName": "analog-testnet",
@@ -10660,8 +10660,8 @@
     ],
     "account": "*25519",
     "subscanUrl": null,
-    "chainspecQrUrl": null,
-    "latestMetadataQrUrl": null,
+    "chainspecQrUrl": "https://metadata.analog.one/qr/analog-testnet_specs.png",
+    "latestMetadataQrUrl": "https://metadata.analog.one/qr/analog-testnet_metadata_latest.apng",
     "isUnknownFeeToken": false,
     "feeToken": null,
     "rpcs": [
@@ -10673,7 +10673,14 @@
     "parathreads": null,
     "paraId": null,
     "relay": null,
-    "balancesConfig": [],
+    "balancesConfig": [
+      {
+        "moduleType": "substrate-native",
+        "moduleConfig": {
+          "logo": "https://raw.githubusercontent.com/TalismanSociety/chaindata/main/assets/tokens/tanlog.svg"
+        }
+      }
+    ],
     "balancesMetadata": [],
     "hasCheckMetadataHash": true
   },

--- a/pub/v1/chains/byGenesisHash/0x0614f7b74a2e47f7c8d8e2a5335be84bdde9402a43f5decdec03200a87c8b943.json
+++ b/pub/v1/chains/byGenesisHash/0x0614f7b74a2e47f7c8d8e2a5335be84bdde9402a43f5decdec03200a87c8b943.json
@@ -6,8 +6,8 @@
   "genesisHash": "0x0614f7b74a2e47f7c8d8e2a5335be84bdde9402a43f5decdec03200a87c8b943",
   "prefix": 12850,
   "name": "Analog Testnet",
-  "themeColor": "#505050",
-  "logo": "https://raw.githubusercontent.com/TalismanSociety/chaindata/main/assets/chains/unknown.svg",
+  "themeColor": "#5d3ef8",
+  "logo": "https://raw.githubusercontent.com/TalismanSociety/chaindata/main/assets/chains/analog-testnet.svg",
   "chainName": "Analog Testnet",
   "chainType": "Live",
   "implName": "analog-testnet",
@@ -23,8 +23,8 @@
   ],
   "account": "*25519",
   "subscanUrl": null,
-  "chainspecQrUrl": null,
-  "latestMetadataQrUrl": null,
+  "chainspecQrUrl": "https://metadata.analog.one/qr/analog-testnet_specs.png",
+  "latestMetadataQrUrl": "https://metadata.analog.one/qr/analog-testnet_metadata_latest.apng",
   "isUnknownFeeToken": false,
   "feeToken": null,
   "rpcs": [
@@ -36,7 +36,14 @@
   "parathreads": null,
   "paraId": null,
   "relay": null,
-  "balancesConfig": [],
+  "balancesConfig": [
+    {
+      "moduleType": "substrate-native",
+      "moduleConfig": {
+        "logo": "https://raw.githubusercontent.com/TalismanSociety/chaindata/main/assets/tokens/tanlog.svg"
+      }
+    }
+  ],
   "balancesMetadata": [],
   "hasCheckMetadataHash": true
 }

--- a/pub/v1/chains/byId/analog-testnet.json
+++ b/pub/v1/chains/byId/analog-testnet.json
@@ -6,8 +6,8 @@
   "genesisHash": "0x0614f7b74a2e47f7c8d8e2a5335be84bdde9402a43f5decdec03200a87c8b943",
   "prefix": 12850,
   "name": "Analog Testnet",
-  "themeColor": "#505050",
-  "logo": "https://raw.githubusercontent.com/TalismanSociety/chaindata/main/assets/chains/unknown.svg",
+  "themeColor": "#5d3ef8",
+  "logo": "https://raw.githubusercontent.com/TalismanSociety/chaindata/main/assets/chains/analog-testnet.svg",
   "chainName": "Analog Testnet",
   "chainType": "Live",
   "implName": "analog-testnet",
@@ -23,8 +23,8 @@
   ],
   "account": "*25519",
   "subscanUrl": null,
-  "chainspecQrUrl": null,
-  "latestMetadataQrUrl": null,
+  "chainspecQrUrl": "https://metadata.analog.one/qr/analog-testnet_specs.png",
+  "latestMetadataQrUrl": "https://metadata.analog.one/qr/analog-testnet_metadata_latest.apng",
   "isUnknownFeeToken": false,
   "feeToken": null,
   "rpcs": [
@@ -36,7 +36,14 @@
   "parathreads": null,
   "paraId": null,
   "relay": null,
-  "balancesConfig": [],
+  "balancesConfig": [
+    {
+      "moduleType": "substrate-native",
+      "moduleConfig": {
+        "logo": "https://raw.githubusercontent.com/TalismanSociety/chaindata/main/assets/tokens/tanlog.svg"
+      }
+    }
+  ],
   "balancesMetadata": [],
   "hasCheckMetadataHash": true
 }

--- a/pub/v1/chains/summary.json
+++ b/pub/v1/chains/summary.json
@@ -1380,8 +1380,8 @@
     "sortIndex": 960,
     "genesisHash": "0x0614f7b74a2e47f7c8d8e2a5335be84bdde9402a43f5decdec03200a87c8b943",
     "name": "Analog Testnet",
-    "themeColor": "#505050",
-    "logo": "https://raw.githubusercontent.com/TalismanSociety/chaindata/main/assets/chains/unknown.svg",
+    "themeColor": "#5d3ef8",
+    "logo": "https://raw.githubusercontent.com/TalismanSociety/chaindata/main/assets/chains/analog-testnet.svg",
     "specName": "analog-testnet",
     "specVersion": "121"
   },

--- a/pub/v1/tokens/all.json
+++ b/pub/v1/tokens/all.json
@@ -806,7 +806,7 @@
     "isDefault": true,
     "symbol": "TANLOG",
     "decimals": 12,
-    "logo": "https://raw.githubusercontent.com/TalismanSociety/chaindata/main/assets/tokens/unknown.svg",
+    "logo": "https://raw.githubusercontent.com/TalismanSociety/chaindata/main/assets/chains/analog-testnet.svg",
     "existentialDeposit": "500",
     "chain": {
       "id": "analog-testnet"

--- a/pub/v1/tokens/byId/analog-testnet-substrate-native.json
+++ b/pub/v1/tokens/byId/analog-testnet-substrate-native.json
@@ -5,7 +5,7 @@
   "isDefault": true,
   "symbol": "TANLOG",
   "decimals": 12,
-  "logo": "https://raw.githubusercontent.com/TalismanSociety/chaindata/main/assets/tokens/unknown.svg",
+  "logo": "https://raw.githubusercontent.com/TalismanSociety/chaindata/main/assets/chains/analog-testnet.svg",
   "existentialDeposit": "500",
   "chain": {
     "id": "analog-testnet"

--- a/pub/v1/tokens/summary.json
+++ b/pub/v1/tokens/summary.json
@@ -453,7 +453,7 @@
     "type": "substrate-native",
     "symbol": "TANLOG",
     "decimals": 12,
-    "logo": "https://raw.githubusercontent.com/TalismanSociety/chaindata/main/assets/tokens/unknown.svg"
+    "logo": "https://raw.githubusercontent.com/TalismanSociety/chaindata/main/assets/chains/analog-testnet.svg"
   },
   {
     "id": "astar-substrate-assets-18446744073709551616-aca",


### PR DESCRIPTION
This extends the existing integration with out testnet by adding the missing logo, link to our metadata portal and native token integration.