### PR TITLE
chore: disambiguate USDTSO from USDT

### DIFF
--- a/data/evm-networks.json
+++ b/data/evm-networks.json
@@ -59,8 +59,7 @@
           {
             "symbol": "USDTSO",
             "coingeckoId": "tether-usd-wormhole",
-            "contractAddress": "0x1cdd2eab61112697626f7b4bb0e23da4febf7b7c",
-            "decimals": 6
+            "contractAddress": "0x1cdd2eab61112697626f7b4bb0e23da4febf7b7c"
           }
         ]
       },

--- a/data/evm-networks.json
+++ b/data/evm-networks.json
@@ -55,11 +55,6 @@
             "symbol": "SHIB",
             "contractAddress": "0x95aD61b0a150d79219dCF64E1E6Cc01f0B64C4cE",
             "coingeckoId": "shiba-inu"
-          },
-          {
-            "symbol": "USDTSO",
-            "coingeckoId": "tether-usd-wormhole",
-            "contractAddress": "0x1cdd2eab61112697626f7b4bb0e23da4febf7b7c"
           }
         ]
       },

--- a/data/evm-networks.json
+++ b/data/evm-networks.json
@@ -55,6 +55,12 @@
             "symbol": "SHIB",
             "contractAddress": "0x95aD61b0a150d79219dCF64E1E6Cc01f0B64C4cE",
             "coingeckoId": "shiba-inu"
+          },
+          {
+            "symbol": "USDTSO",
+            "coingeckoId": "tether-usd-wormhole",
+            "contractAddress": "0x1cdd2eab61112697626f7b4bb0e23da4febf7b7c",
+            "decimals": 6
           }
         ]
       },

--- a/data/known-evm-networks-overrides.json
+++ b/data/known-evm-networks-overrides.json
@@ -4,6 +4,20 @@
     "balancesConfig": {
       "evm-native": {
         "coingeckoId": "ethereum"
+      },
+      "evm-erc20": {
+        "tokens": [
+          {
+            "symbol": "USDCPO",
+            "coingeckoId": "usd-coin-pos-wormhole",
+            "contractAddress": "0x566957ef80f9fd5526cd2bef8be67035c0b81130"
+          },
+          {
+            "symbol": "USDTSO",
+            "coingeckoId": "tether-usd-wormhole",
+            "contractAddress": "0x1cdd2eab61112697626f7b4bb0e23da4febf7b7c"
+          }
+        ]
       }
     }
   },


### PR DESCRIPTION
Noticed that there were two 'UDST' tokens on Ethereum mainnet in the tokens settings in Talisman. Because the token symbol is taken from the contract in our externally fetched tokens, USDTO (wormhole bridged USDT from Solana https://www.coingecko.com/en/coins/bridged-tether-wormhole) was showing up as USDT.

This PR adds USDTSO as a specifically defined asset on the Ethereum mainnet balances config to prevent it being overwritten by the externally fetched definitions.