### PR TITLE
feat: add analog mainnet

### DIFF
--- a/data/chaindata.json
+++ b/data/chaindata.json
@@ -476,6 +476,21 @@
     }
   },
   {
+    "id": "analog-timechain",
+    "name": "Analog Timechain",
+    "chainspecQrUrl": "https://metadata.analog.one/qr/analog-timechain_specs.png",
+    "latestMetadataQrUrl": "https://metadata.analog.one/qr/analog-timechain_metadata_latest.apng",
+    "rpcs": ["wss://rpc.timechain.analog.one"],
+    "themeColor": "#5d3ef8",
+    "balancesConfig": {
+      "substrate-native": {
+        "logo": "./assets/tokens/tanlog.svg",
+        "symbol": "ANLOG",
+        "decimals": 12
+      }
+    }
+  },
+  {
     "id": "ares-odyssey",
     "name": "Ares Odyssey Standalone",
     "rpcs": [],

--- a/data/testnets-chaindata.json
+++ b/data/testnets-chaindata.json
@@ -39,7 +39,9 @@
     "themeColor": "#5d3ef8",
     "balancesConfig": {
       "substrate-native": {
-        "logo": "./assets/tokens/tanlog.svg"
+        "logo": "./assets/tokens/tanlog.svg",
+        "symbol": "TANLOG",
+        "decimals": 12
       }
     }
   },


### PR DESCRIPTION
This adds our soft-launched mainnet. Let me know if I should rerun the export build as well.