### PR TITLE
mosaic chain added

### DIFF
--- a/assets/chains/mosaic.svg
+++ b/assets/chains/mosaic.svg
@@ -1,0 +1,15 @@
+<svg width="48" height="48" viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_31_709)">
+<path d="M0 12C0 5.37258 5.37258 0 12 0H36C42.6274 0 48 5.37258 48 12V36C48 42.6274 42.6274 48 36 48H12C5.37258 48 0 42.6274 0 36V12Z" fill="url(#paint0_linear_31_709)"/>
+<path d="M32.5039 11.8985L29.9741 15.5014L24 7L18.0259 15.5014L15.4961 11.8985L7 24L15.4961 36.1015L18.0259 32.4986L24 41L29.9741 32.4986L32.5039 36.1015L41 24L32.5039 11.8985ZM24 31.2031L21.4702 27.6001L18.9405 24L21.4702 20.3999L24 16.7969L26.5298 20.3999L29.0595 24L26.5298 27.6001L24 31.2031Z" fill="white"/>
+</g>
+<defs>
+<linearGradient id="paint0_linear_31_709" x1="24" y1="0" x2="24" y2="48" gradientUnits="userSpaceOnUse">
+<stop stop-color="#FF9BC0"/>
+<stop offset="1" stop-color="#7744E4"/>
+</linearGradient>
+<clipPath id="clip0_31_709">
+<rect width="48" height="48" fill="white"/>
+</clipPath>
+</defs>
+</svg>

--- a/assets/tokens/mos.svg
+++ b/assets/tokens/mos.svg
@@ -1,0 +1,15 @@
+<svg width="48" height="48" viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_31_750)">
+<circle cx="24" cy="24" r="24" fill="url(#paint0_linear_31_750)"/>
+<path d="M32.5039 11.8985L29.9741 15.5014L24 7L18.0259 15.5014L15.4961 11.8985L7 24L15.4961 36.1015L18.0259 32.4986L24 41L29.9741 32.4986L32.5039 36.1015L41 24L32.5039 11.8985ZM24 31.2031L21.4702 27.6001L18.9405 24L21.4702 20.3999L24 16.7969L26.5298 20.3999L29.0595 24L26.5298 27.6001L24 31.2031Z" fill="white"/>
+</g>
+<defs>
+<linearGradient id="paint0_linear_31_750" x1="24" y1="0" x2="24" y2="48" gradientUnits="userSpaceOnUse">
+<stop stop-color="#FF9BC0"/>
+<stop offset="1" stop-color="#7744E4"/>
+</linearGradient>
+<clipPath id="clip0_31_750">
+<rect width="48" height="48" fill="white"/>
+</clipPath>
+</defs>
+</svg>

--- a/data/networks-polkadot.yaml
+++ b/data/networks-polkadot.yaml
@@ -2346,6 +2346,21 @@
     coingeckoId: exosama-network
   rpcs: []
   relay: polkadot
+- id: mosaic
+  name: Mosaic
+  isDefault: false
+  nativeCurrency:
+    logo: ./assets/tokens/mos.svg
+  blockExplorerUrls:
+    - https://mainnet-explorer.mosaicchain.io/
+  rpcs:
+    - wss://mainnet-explorer.mosaicchain.io/MosaicNode1/chain
+    - wss://mainnet-explorer.mosaicchain.io/MosaicNode2/chain
+    - wss://mainnet-explorer.mosaicchain.io/MosaicNode3/chain
+    - wss://mainnet-explorer.mosaicchain.io/MosaicNode4/chain
+    - wss://mainnet-explorer.mosaicchain.io/MosaicNode5/chain
+    - wss://mainnet-explorer.mosaicchain.io/MosaicNode6/chain
+  relay: polkadot
 - id: myriad
   name: Myriad
   isDefault: false


### PR DESCRIPTION
Adds [Mosaic](https://mosaicchain.io), a Polkadot parachain, to `data/networks-polkadot.yaml`, along with its chain and token logos.

### Network details

| | |
|---|---|
| id | `mosaic` |
| relay | Polkadot |
| token | MOS, 18 decimals |
| ss58 prefix | 0 |
| runtime | `mosaic-chain` v109 |
| rpcs | 6 |

### Notes on the config

- **`isDefault: false`**
- **No `coingeckoId`** — MOS is not listed on CoinGecko yet.
- **Six RPCs listed** though the build keeps the top five by health; the sixth is a spare for when one goes unhealthy.
- **Symbol, decimals, prefix, genesis hash and spec version are all left to the build** to fetch from the chain, as usual.

### Verification

- All six RPCs accept `wss://` connections and answer `system_chain` with "Mosaic Chain". `system_properties` reports `MOS` / 18 / ss58 `0` consistently across every node.
- `validate-schema` passes against `DotNetworksConfigFileSchema`.
- `generate-schemas` regenerates all four JSON schemas byte-identical — no schema drift.
- Ran `getNetworkLogoUrl` and `getTokenLogoUrl` against the new assets: both resolve, so the network and the MOS token each render a logo despite the missing `coingeckoId`.

Mosaic won't appear in `pub/` until `fetch-external` has recorded RPC health and chain specs for the new id — expected on a first-time addition.
