### PR TITLE
Add Rotko RPC endpoints to Polkadot/Kusama/Paseo system chains

### DIFF
--- a/data/networks-polkadot.yaml
+++ b/data/networks-polkadot.yaml
@@ -1273,6 +1273,7 @@
   rpcs:
     - wss://encointer-kusama-rpc.n.dwellir.com
     - wss://rpc-encointer-kusama.luckyfriday.io
+    - wss://encointer-kusama.rotko.net
   relay: kusama
 - id: enjin-matrixchain
   name: Enjin Matrix
@@ -2149,6 +2150,7 @@
     - wss://ksm-rpc.stakeworld.io/assethub
     - wss://assethub-kusama.api.onfinality.io/public-ws
     - wss://asset-hub-kusama-rpc.n.dwellir.com
+    - wss://asset-hub-kusama.rotko.net
   relay: kusama
   tokens:
     substrate-assets:
@@ -2178,6 +2180,7 @@
     - wss://ksm-rpc.stakeworld.io/bridgehub
     - wss://bridgehub-kusama.api.onfinality.io/public-ws
     - wss://bridge-hub-kusama-rpc.n.dwellir.com
+    - wss://bridge-hub-kusama.rotko.net
   relay: kusama
 - id: kusama-coretime
   name: Kusama Coretime
@@ -2195,6 +2198,7 @@
     - wss://ksm-rpc.stakeworld.io/coretime
     - wss://coretime-kusama.api.onfinality.io/public-ws
     - wss://coretime-kusama-rpc.n.dwellir.com
+    - wss://coretime-kusama.rotko.net
   relay: kusama
 - id: kusama-people
   name: Kusama People
@@ -2212,6 +2216,7 @@
     - wss://ksm-rpc.stakeworld.io/people
     - wss://people-kusama.api.onfinality.io/public-ws
     - wss://people-kusama-rpc.n.dwellir.com
+    - wss://people-kusama.rotko.net
   relay: kusama
 - id: kusari
   name: Kusari
@@ -2919,6 +2924,7 @@
     - wss://bridgehub-polkadot.api.onfinality.io/public-ws
     - wss://bridge-hub-polkadot-rpc.n.dwellir.com
     - wss://rpc-bridge-hub-polkadot.stakeworld.io
+    - wss://bridge-hub-polkadot.rotko.net
   relay: polkadot
 - id: polkadot-collectives
   name: Polkadot Collectives
@@ -2935,6 +2941,7 @@
     - wss://dot-rpc.stakeworld.io/collectives
     - wss://collectives.api.onfinality.io/public-ws
     - wss://collectives-polkadot-rpc.n.dwellir.com
+    - wss://collectives-polkadot.rotko.net
   relay: polkadot
 - id: polkadot-coretime
   name: Polkadot Coretime
@@ -2948,6 +2955,7 @@
     - wss://coretime-polkadot.api.onfinality.io/public-ws
     - wss://coretime-polkadot-rpc.n.dwellir.com
     - wss://rpc-coretime-polkadot.luckyfriday.io
+    - wss://coretime-polkadot.rotko.net
   relay: polkadot
 - id: polkadot-people
   name: Polkadot People
@@ -2962,6 +2970,7 @@
     - wss://people-polkadot.api.onfinality.io/public-ws
     - wss://people-polkadot-rpc.n.dwellir.com
     - wss://rpc-people-polkadot.stakeworld.io
+    - wss://people-polkadot.rotko.net
   relay: polkadot
 - id: polkasmith
   name: PolkaSmith
@@ -4710,6 +4719,7 @@
   isTestnet: true
   rpcs:
     - wss://pas-rpc.stakeworld.io/people
+    - wss://people-paseo.rotko.net
   relay: paseo-testnet
 - id: paseo-aventus
   name: Aventus


### PR DESCRIPTION
Adds Rotko public RPC endpoints to the Polkadot, Kusama and Paseo system chains.

All endpoints are live and were verified with a `system_chain` call before submitting:

| Chain | Endpoint |
|-------|----------|
| Polkadot Bridge Hub | wss://bridge-hub-polkadot.rotko.net |
| Polkadot Collectives | wss://collectives-polkadot.rotko.net |
| Polkadot Coretime | wss://coretime-polkadot.rotko.net |
| Polkadot People | wss://people-polkadot.rotko.net |
| Kusama Asset Hub | wss://asset-hub-kusama.rotko.net |
| Kusama Bridge Hub | wss://bridge-hub-kusama.rotko.net |
| Kusama Coretime | wss://coretime-kusama.rotko.net |
| Encointer (Kusama) | wss://encointer-kusama.rotko.net |
| Kusama People | wss://people-kusama.rotko.net |
| Paseo People | wss://people-paseo.rotko.net |

Rotko already provides the Hydration RPC in this dataset (`wss://hydration.rotko.net`).